### PR TITLE
Add support for testing property constraint using the getObject() function from the context

### DIFF
--- a/Docs/TestCases.md
+++ b/Docs/TestCases.md
@@ -61,6 +61,21 @@ class ConstraintTest extends ConstraintTestCase
 }
 ```
 
+Property constraints can access the object containing the value we are trying to validate from the context: `$this->constraint->getObject()`. To provide that object in your test you can pass it as the second argument of the `$this->validate()` function provided by the ConstraintTestCase:
+
+```php
+class ConstraintTest extends ConstraintTestCase
+{
+    public function testValidate(): void
+    {
+        $object = // ...
+
+        $violations = $this->validate($object->property, $object);
+
+        self::assertEmpty($violations);
+    }
+}
+```
 
 ### ControllerTestCase
 

--- a/TestCase/ConstraintTestCase.php
+++ b/TestCase/ConstraintTestCase.php
@@ -70,8 +70,9 @@ class ConstraintTestCase extends TestCase
      *
      * @return ConstraintViolationListInterface|ConstraintViolationInterface[]
      */
-    public function validate($value): ConstraintViolationListInterface
+    public function validate($value, $object = null): ConstraintViolationListInterface
     {
+        $this->context->setNode($value, $object, null, null);
         $violations = $this->validator->validate($value, $this->constraint);
 
         return $violations ?? $this->context->getViolations();

--- a/Tests/Resources/Validator/DummyConstraintWithObject.php
+++ b/Tests/Resources/Validator/DummyConstraintWithObject.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace RichCongress\Bundle\UnitBundle\Tests\Resources\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class DummyConstraintWithObject
+ *
+ * @package   RichCongress\Bundle\UnitBundle\Tests\Resources\Validator
+ * @author    Matthias Devlamynck <mdevlamynck@richcongress.com>
+ * @copyright 2014 - 2020 RichCongress (https://www.richcongress.com)
+ */
+class DummyConstraintWithObject extends Constraint
+{
+}

--- a/Tests/Resources/Validator/DummyConstraintWithObjectValidator.php
+++ b/Tests/Resources/Validator/DummyConstraintWithObjectValidator.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace RichCongress\Bundle\UnitBundle\Tests\Resources\Validator;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+/**
+ * Class DummyConstraintWithObjectValidator
+ *
+ * @package   RichCongress\Bundle\UnitBundle\Tests\Resources\Validator
+ * @author    Matthias Devlamynck <mdevlamynck@richcongress.com>
+ * @copyright 2014 - 2020 RichCongress (https://www.richcongress.com)
+ */
+class DummyConstraintWithObjectValidator implements ConstraintValidatorInterface
+{
+    /**
+     * @var ExecutionContextInterface
+     */
+    public $context;
+
+    /**
+     * @param ExecutionContextInterface $context
+     *
+     * @return void
+     */
+    public function initialize(ExecutionContextInterface $context): void
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * @param mixed                      $value
+     * @param Constraint|DummyConstraint $constraint
+     *
+     * @return void
+     */
+    public function validate($value, Constraint $constraint): void
+    {
+        if ($this->context->getObject()->makeItFail) {
+            $this->context->addViolation('No');
+        }
+    }
+}

--- a/Tests/TestCase/ConstraintTestCaseTest.php
+++ b/Tests/TestCase/ConstraintTestCaseTest.php
@@ -6,6 +6,8 @@ use RichCongress\Bundle\UnitBundle\Stubs\ValidationContextStub;
 use RichCongress\Bundle\UnitBundle\TestCase\ConstraintTestCase;
 use RichCongress\Bundle\UnitBundle\Tests\Resources\Validator\DummyConstraint;
 use RichCongress\Bundle\UnitBundle\Tests\Resources\Validator\DummyConstraintValidator;
+use RichCongress\Bundle\UnitBundle\Tests\Resources\Validator\DummyConstraintWithObject;
+use RichCongress\Bundle\UnitBundle\Tests\Resources\Validator\DummyConstraintWithObjectValidator;
 
 /**
  * Class ConstraintTestCaseTest
@@ -68,5 +70,19 @@ class ConstraintTestCaseTest extends ConstraintTestCase
         $this->constraint->makeItFail = true;
 
         self::assertCount(1, $this->validate(''));
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidatePropertyWithObjectInContext(): void
+    {
+        $this->constraint = new DummyConstraintWithObject();
+        $this->validator = new DummyConstraintWithObjectValidator();
+        $this->setUp();
+
+        self::assertEmpty($this->validate('', (object) ['makeItFail' => false]));
+
+        self::assertCount(1, $this->validate('', (object) ['makeItFail' => true]));
     }
 }


### PR DESCRIPTION
For property constraints using `$this->context->getObject()` we need a way to provide a value for that object in tests. This MR adds support for that in the form of an optional parameter to the function `$this->validate()`.